### PR TITLE
Add Production Draft Check to Tests

### DIFF
--- a/docs/ninjaone/automations/todyl-deployment.md
+++ b/docs/ninjaone/automations/todyl-deployment.md
@@ -6,7 +6,7 @@ title_meta: 'Todyl Deployment Script'
 keywords: ['Todyl','Agent','Windows','Deployment']
 description: 'This script automates the deployment of the Todyl Agent on Windows machines by downloading the latest installer, running the installation silently, and validating that the agent has been successfully installed.'
 tags:  ['windows']
-draft: true
+draft: false
 unlisted: false
 ---
 

--- a/docs/ninjaone/automations/todyl-deployment.md
+++ b/docs/ninjaone/automations/todyl-deployment.md
@@ -6,7 +6,7 @@ title_meta: 'Todyl Deployment Script'
 keywords: ['Todyl','Agent','Windows','Deployment']
 description: 'This script automates the deployment of the Todyl Agent on Windows machines by downloading the latest installer, running the installation silently, and validating that the agent has been successfully installed.'
 tags:  ['windows']
-draft: false
+draft: true
 unlisted: false
 ---
 
@@ -28,7 +28,7 @@ Search and select `Todyl Deployment`
 
 ## Automation Setup/Import
 
-[Automation Configuration]((https://github.com/ProVal-Tech/ninjarmm/blob/main/scripts/todyl-deployment.ps1))
+<!-- [Automation Configuration]((https://github.com/ProVal-Tech/ninjarmm/blob/main/scripts/todyl-deployment.ps1)) -->
 
 ## Output
 

--- a/docs/ninjaone/automations/zorus-deployment.md
+++ b/docs/ninjaone/automations/zorus-deployment.md
@@ -28,7 +28,7 @@ Search and select `Zorus Deployment`
 
 ## Automation Setup/Import
 
-[Automation Configuration]((https://github.com/ProVal-Tech/ninjarmm/blob/main/scripts/zorus-deployment.ps1))
+<!-- [Automation Configuration]((https://github.com/ProVal-Tech/ninjarmm/blob/main/scripts/zorus-deployment.ps1)) -->
 
 ## Output
 

--- a/docs/ninjaone/automations/zorus-deployment.md
+++ b/docs/ninjaone/automations/zorus-deployment.md
@@ -24,7 +24,7 @@ Search and select `Zorus Deployment`
 
 ## Dependencies
 - [cPVAL Zorus Token Key](/docs/a3bdf78e-b4fd-499e-9e30-3eb49f6653cd)
-- [cPVAL Zorus Uninstallation Password](/docs/a3bdf78e-b4fd-499e-9e30-3eb49f6653cd)
+- [cPVAL Zorus Uninstallation Password](/docs/a5be5729-cb20-4ab6-834e-d18d361cee97)
 
 ## Automation Setup/Import
 

--- a/docs/ninjaone/automations/zorus-deployment.md
+++ b/docs/ninjaone/automations/zorus-deployment.md
@@ -6,7 +6,7 @@ title_meta: 'Zorus Deployment'
 keywords: ['Zorus','Agent','Windows','Deployment']
 description: 'This script automates the deployment of the Zorus agent across Windows machines by downloading the required installer, executing the installation silently, and verifying that the agent is successfully installed.'
 tags:  ['windows']
-draft: true
+draft: false
 unlisted: false
 ---
 

--- a/docs/ninjaone/custom-fields/cpval-todyl-desktop-policy-key.md
+++ b/docs/ninjaone/custom-fields/cpval-todyl-desktop-policy-key.md
@@ -6,7 +6,7 @@ title_meta: 'cPVAL Todyl Desktop Policy Key'
 keywords: ['Todyl','Agent','Windows','Deployment']
 description: 'Todyl Deployment Key for Desktop Agents'
 tags:  ['windows']
-draft: true
+draft: false
 unlisted: false
 ---
 
@@ -15,9 +15,9 @@ Todyl Deployment Key for Desktop Agents
 
 ## Details
 
-| Label | Field Name | Definition Scope | Type | Required | Default Value | Technician Permission | Automation Permission | API Permission | Description | Tool Tip | Footer Text |Custom Field Tab Name |
-| ----- | ---------- | ---------------- | ---- | --------- | --------------------- | --------------------- | -------------- | ----------- | -------- | ----------- |----------- | ----------- |
-| cPVAL Todyl Desktop Policy Key| cpvalTodylDesktopPolicyKey | Organization | Text | Yes | - | Editable | Read/Write | Read/Write | Todyl Deployment Key for Desktop Agents | - | - |Todyl Deployment|
+| Label                          | Field Name                 | Definition Scope | Type | Required | Default Value | Technician Permission | Automation Permission | API Permission | Description                             | Tool Tip | Footer Text | Custom Field Tab Name |
+| ------------------------------ | -------------------------- | ---------------- | ---- | -------- | ------------- | --------------------- | --------------------- | -------------- | --------------------------------------- | -------- | ----------- | --------------------- |
+| cPVAL Todyl Desktop Policy Key | cpvalTodylDesktopPolicyKey | Organization     | Text | Yes      | -             | Editable              | Read/Write            | Read/Write     | Todyl Deployment Key for Desktop Agents | -        | -           | Todyl Deployment      |
 
 ## Dependencies
 - [Todyl Deployment](/docs/3ed0cf6e-1e51-419e-8fd3-5d689ef6f629)

--- a/docs/ninjaone/custom-fields/cpval-todyl-laptop-policy-key.md
+++ b/docs/ninjaone/custom-fields/cpval-todyl-laptop-policy-key.md
@@ -6,7 +6,7 @@ title_meta: 'cPVAL Todyl Laptop Policy Key'
 keywords: ['Todyl','Agent','Windows','Deployment']
 description: 'Todyl Deployment Key for laptop Agents'
 tags:  ['windows']
-draft: true
+draft: false
 unlisted: false
 ---
 
@@ -15,9 +15,9 @@ Todyl Deployment Key for laptop Agents
 
 ## Details
 
-| Label | Field Name | Definition Scope | Type | Required | Default Value | Technician Permission | Automation Permission | API Permission | Description | Tool Tip | Footer Text |Custom Field Tab Name |
-| ----- | ---------- | ---------------- | ---- | --------- | --------------------- | --------------------- | -------------- | ----------- | -------- | ----------- |----------- | ----------- |
-| cPVAL Todyl Laptop Policy Key| cpvalTodyllaptopPolicyKey | Organization | Text | Yes | - | Editable | Read/Write | Read/Write | Todyl Deployment Key for laptop Agents | - | - |Todyl Deployment|
+| Label                         | Field Name                | Definition Scope | Type | Required | Default Value | Technician Permission | Automation Permission | API Permission | Description                            | Tool Tip | Footer Text | Custom Field Tab Name |
+| ----------------------------- | ------------------------- | ---------------- | ---- | -------- | ------------- | --------------------- | --------------------- | -------------- | -------------------------------------- | -------- | ----------- | --------------------- |
+| cPVAL Todyl Laptop Policy Key | cpvalTodyllaptopPolicyKey | Organization     | Text | Yes      | -             | Editable              | Read/Write            | Read/Write     | Todyl Deployment Key for laptop Agents | -        | -           | Todyl Deployment      |
 
 ## Dependencies
 - [Todyl Deployment](/docs/3ed0cf6e-1e51-419e-8fd3-5d689ef6f629)

--- a/docs/ninjaone/custom-fields/cpval-todyl-server-policy-key.md
+++ b/docs/ninjaone/custom-fields/cpval-todyl-server-policy-key.md
@@ -6,7 +6,7 @@ title_meta: 'cPVAL Todyl Server Policy Key'
 keywords: ['Todyl','Agent','Windows','Deployment']
 description: 'Todyl Deployment Key for Server Agents'
 tags:  ['windows']
-draft: true
+draft: false
 unlisted: false
 ---
 
@@ -15,9 +15,9 @@ Todyl Deployment Key for Servers.
 
 ## Details
 
-| Label | Field Name | Definition Scope | Type | Required | Default Value | Technician Permission | Automation Permission | API Permission | Description | Tool Tip | Footer Text |Custom Field Tab Name |
-| ----- | ---------- | ---------------- | ---- | --------- | --------------------- | --------------------- | -------------- | ----------- | -------- | ----------- |----------- | ----------- |
-| cPVAL Todyl Server Policy Key| cpvalTodylServerPolicyKey | Organization | Text | Yes | - | Editable | Read/Write | Read/Write | Todyl Deployment Key for Servers. | - | - |Todyl Deployment|
+| Label                         | Field Name                | Definition Scope | Type | Required | Default Value | Technician Permission | Automation Permission | API Permission | Description                       | Tool Tip | Footer Text | Custom Field Tab Name |
+| ----------------------------- | ------------------------- | ---------------- | ---- | -------- | ------------- | --------------------- | --------------------- | -------------- | --------------------------------- | -------- | ----------- | --------------------- |
+| cPVAL Todyl Server Policy Key | cpvalTodylServerPolicyKey | Organization     | Text | Yes      | -             | Editable              | Read/Write            | Read/Write     | Todyl Deployment Key for Servers. | -        | -           | Todyl Deployment      |
 
 ## Dependencies
 - [Todyl Deployment](/docs/3ed0cf6e-1e51-419e-8fd3-5d689ef6f629)

--- a/docs/ninjaone/custom-fields/cpval-zorus-token-key.md
+++ b/docs/ninjaone/custom-fields/cpval-zorus-token-key.md
@@ -6,7 +6,7 @@ title_meta: 'cPVAL Zorus Token Key'
 keywords: ['Zorus','Agent','Windows','Deployment']
 description: 'Deployment token generated within the Zorus portal, for deploying the Zorus agent.'
 tags:  ['windows']
-draft: true
+draft: false
 unlisted: false
 ---
 
@@ -15,9 +15,9 @@ Deployment token generated within the Zorus portal for deploying the Zorus agent
 
 ## Details
 
-| Label | Field Name | Definition Scope | Type | Required | Default Value | Technician Permission | Automation Permission | API Permission | Description | Tool Tip | Footer Text |Custom Field Tab Name |
-| ----- | ---------- | ---------------- | ---- | --------- | --------------------- | --------------------- | -------------- | ----------- | -------- | ----------- |----------- | ----------- |
-|cPVAL Zorus Token Key | cpvalZorusTokenKey | Organization | Text | Yes | - | Editable | Read/Write | Read/Write | Deployment token generated within the Zorus portal, for deploying the Zorus agent. | - | - |Zorus Deployment|
+| Label                 | Field Name         | Definition Scope | Type | Required | Default Value | Technician Permission | Automation Permission | API Permission | Description                                                                        | Tool Tip | Footer Text | Custom Field Tab Name |
+| --------------------- | ------------------ | ---------------- | ---- | -------- | ------------- | --------------------- | --------------------- | -------------- | ---------------------------------------------------------------------------------- | -------- | ----------- | --------------------- |
+| cPVAL Zorus Token Key | cpvalZorusTokenKey | Organization     | Text | Yes      | -             | Editable              | Read/Write            | Read/Write     | Deployment token generated within the Zorus portal, for deploying the Zorus agent. | -        | -           | Zorus Deployment      |
 
 ## Dependencies
 - [Zorus Deployment](/docs/da444ba9-ae51-48f8-8913-35f206579b04)

--- a/docs/ninjaone/custom-fields/cpval-zorus-uninstallation-password.md
+++ b/docs/ninjaone/custom-fields/cpval-zorus-uninstallation-password.md
@@ -6,7 +6,7 @@ title_meta: 'cPVAL Zorus Uninstallation Password'
 keywords: ['Zorus','Agent','Windows','Deployment']
 description: 'Zorus agent uninstallation password'
 tags: ['windows']
-draft: true
+draft: false
 unlisted: false
 ---
 
@@ -16,9 +16,9 @@ unlisted: false
 
 ## Details
 
-| Label | Field Name | Definition Scope | Type | Required | Default Value | Technician Permission | Automation Permission | API Permission | Description | Tool Tip | Footer Text |Custom Field Tab Name |
-| ----- | ---------- | ---------------- | ---- | --------- | --------------------- | --------------------- | -------------- | ----------- | -------- | ----------- |----------- | ----------- |
-| cPVAL Zorus Uninstallation Password | cpvalZorusUninstallationPassword | Organization | Text | Yes | - | Editable | Read/Write | Read/Write | Zorus agent uninstallation password. To utilize this feature set this variable to your desired password. Only use this feature if you have a secure way to store/remember the desired password. | - | - |Zorus Deployment|
+| Label                               | Field Name                       | Definition Scope | Type | Required | Default Value | Technician Permission | Automation Permission | API Permission | Description                                                                                                                                                                                     | Tool Tip | Footer Text | Custom Field Tab Name |
+| ----------------------------------- | -------------------------------- | ---------------- | ---- | -------- | ------------- | --------------------- | --------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- | --------------------- |
+| cPVAL Zorus Uninstallation Password | cpvalZorusUninstallationPassword | Organization     | Text | Yes      | -             | Editable              | Read/Write            | Read/Write     | Zorus agent uninstallation password. To utilize this feature set this variable to your desired password. Only use this feature if you have a secure way to store/remember the desired password. | -        | -           | Zorus Deployment      |
 
 ## Dependencies
 - [Zorus Deployment](/docs/da444ba9-ae51-48f8-8913-35f206579b04)

--- a/docs/ninjaone/custom-fields/cpval-zorus-uninstallation-password.md
+++ b/docs/ninjaone/custom-fields/cpval-zorus-uninstallation-password.md
@@ -1,6 +1,6 @@
 ---
-id: 'a3bdf78e-b4fd-499e-9e30-3eb49f6653cd'
-slug: /a3bdf78e-b4fd-499e-9e30-3eb49f6653cd
+id: 'a5be5729-cb20-4ab6-834e-d18d361cee97'
+slug: /a5be5729-cb20-4ab6-834e-d18d361cee97
 title: 'cPVAL Zorus Uninstallation Password'
 title_meta: 'cPVAL Zorus Uninstallation Password'
 keywords: ['Zorus','Agent','Windows','Deployment']

--- a/tests/DocumentStandards.Tests.ps1
+++ b/tests/DocumentStandards.Tests.ps1
@@ -52,6 +52,15 @@ foreach ($doc in $docs) {
             Value = $null
         }
     }
+
+    $isDraft = $content | Select-String -Pattern '^draft: true'
+    if (($slug -or $id) -and $isDraft) {
+        $errorList += [PSCustomObject]@{
+            Path = $doc.FullName
+            Type = 'ProductionDocInDraftMode'
+            Value = $null
+        }
+    }
 }
 
 # Check for unused static files in the repository


### PR DESCRIPTION
This pull request adds an additional validation to the document standards test script to ensure production documents are not mistakenly marked as drafts. The main change is:

Document validation:

* Updated `DocumentStandards.Tests.ps1` to check if a document with a `slug` or `id` is in draft mode (`draft: true`), and if so, adds an error to the error list to flag this issue.