### PR TITLE
Update windows 11 upgrade compatibility

### DIFF
--- a/docs/cwa/dataviews/windows-11-upgrade-compatibility.md
+++ b/docs/cwa/dataviews/windows-11-upgrade-compatibility.md
@@ -51,5 +51,6 @@ This document shows which machines are eligible to upgrade to Windows 11 based o
 | Column Name          | Operator | Comparator     | Color  |
 |---------------------|----------|----------------|--------|
 | Compatibility Check  | Equals   | Not Capable    | Red    |
+| Compatibility Check  | Equals   | Not Capable: FreeDisk <64GB  | Red  |
 | Compatibility Check  | Equals   | Undetermined    | Orange |
 | Compatibility Check  | Equals   | Capable        | Green  |


### PR DESCRIPTION
Updated windows 11 upgrade compatibility.
Bug detected, when all checks passed but the system drive size detected less than 64 GB marked as undetermined. Changed the verbiage for such cases as 'Not Capable: FreeDisk <64GB'.