### PR TITLE
Add docs for installing uBlock Origin Lite extension

### DIFF
--- a/docs/immybot/tasks/install-extension-ublock-origin-lite.md
+++ b/docs/immybot/tasks/install-extension-ublock-origin-lite.md
@@ -1,0 +1,15 @@
+---
+id: '187ae3f2-4649-4954-ba62-8496d8f9a02d'
+slug: /187ae3f2-4649-4954-ba62-8496d8f9a02d
+title: 'Install Extension uBlock Origin Lite'
+title_meta: 'Install Extension uBlock Origin Lite'
+keywords: ['install extension', 'ublock origin lite', 'browser extension']
+description: 'Install the uBlock Origin Lite extension using ImmyBot.'
+tags: ['software']
+draft: false
+unlisted: false
+---
+
+## Description
+
+[Task Configuration](https://github.com/ProVal-Tech/immybot/blob/main/tasks/install-extension-ublock-origin-lite.toml)


### PR DESCRIPTION
Created a new documentation file describing how to install the uBlock Origin Lite browser extension using ImmyBot, including metadata and a link to the related task configuration.