### PR TITLE
Update automation configuration link to shell script

### DIFF
--- a/docs/ninjaone/automations/install-cisco-umbrella-root-ca-certificate-macintosh.md
+++ b/docs/ninjaone/automations/install-cisco-umbrella-root-ca-certificate-macintosh.md
@@ -27,7 +27,7 @@ Downloads and installs the Cisco Umbrella Root CA certificate to the Local Machi
 
 ## Automation Setup/Import
 
-[Automation Configuration](https://github.com/ProVal-Tech/ninjarmm/blob/main/scripts/install-cisco-umbrella-root-ca-certificate-macintosh.ps1)
+[Automation Configuration](https://github.com/ProVal-Tech/ninjarmm/blob/main/scripts/install-cisco-umbrella-root-ca-certificate-macintosh.sh)
 
 ## Output
 


### PR DESCRIPTION
I’ve updated the Automation Configuration link. It was previously set with a .ps1 extension instead of .sh, which was preventing the URL from opening correctly.