### PR TITLE
Create uninstall-webroot-forced.md

### DIFF
--- a/docs/ninjaone/automations/uninstall-webroot-forced.md
+++ b/docs/ninjaone/automations/uninstall-webroot-forced.md
@@ -1,0 +1,22 @@
+---
+id: '4691d03e-d332-4050-a97e-47af9a791fa5'
+slug: /4691d03e-d332-4050-a97e-47af9a791fa5
+title: 'Uninstall Webroot - Forced'
+title_meta: 'Uninstall Webroot - Forced'
+keywords: ['webroot', 'uninstall']
+description: 'Uninstall Webroot from a device using a forced uninstall method.'
+tags: ['software']
+draft: false
+unlisted: false
+---
+
+## Overview
+This automation uninstalls Webroot from a device using a forced uninstall method. It is useful when the standard uninstallation process fails or when Webroot is not responding. Requires the target device to be booted into Safe Mode.
+
+## Automation Setup/Import
+
+[Automation Configuration](https://github.com/ProVal-Tech/ninjarmm/blob/main/scripts/uninstall-webroot-forced.ps1)
+
+## Output
+
+- Activity Details


### PR DESCRIPTION
This pull request adds new documentation for a forced Webroot uninstallation automation. The documentation provides an overview, setup instructions, and output details for the automation.

Documentation additions:

* Added a new markdown file `uninstall-webroot-forced.md` that describes the purpose, setup, and output of the "Uninstall Webroot - Forced" automation, including a link to the relevant PowerShell script.