### PR TITLE
Mark CWA monitor and script docs as unlisted

### DIFF
--- a/docs/cwa/monitors/agent-e-mail-machine-back-online.md
+++ b/docs/cwa/monitors/agent-e-mail-machine-back-online.md
@@ -7,7 +7,7 @@ keywords: ['monitor', 'alert', 'connectwise', 'email', 'computer']
 description: 'This document provides a detailed overview of a monitor that alerts when a computer checks in with a valid email address for the Online Alert E-mail EDF in ConnectWise Automate. It includes information on the alert template and dependencies required for setup.'
 tags: ['connectwise', 'email', 'setup']
 draft: false
-unlisted: false
+unlisted: true
 ---
 
 ## Summary

--- a/docs/cwa/monitors/windows-fast-boot-enabled.md
+++ b/docs/cwa/monitors/windows-fast-boot-enabled.md
@@ -7,7 +7,7 @@ keywords: ['monitor', 'fast', 'boot', 'windows', 'disable']
 description: 'This document outlines a monitor that detects machines with Windows Fast Boot enabled and provides an Autofix for Windows-based machines to disable it. It is intended for workstations and should not be run on servers.'
 tags: ['windows']
 draft: false
-unlisted: false
+unlisted: true
 ---
 
 ## Summary

--- a/docs/cwa/scripts/agent-id-assignment-discrepancy-autofix.md
+++ b/docs/cwa/scripts/agent-id-assignment-discrepancy-autofix.md
@@ -7,7 +7,7 @@ keywords: ['automate', 'agent', 'ticket', 'reinstall', 'discrepancy']
 description: 'This document provides a detailed overview of a script designed to reinstall the Automate agent for machines that share the same agent ID. It outlines the process of creating tickets for failed installations and highlights specific dependencies and variables necessary for successful execution. The script is intended for environments where Mac Signup Matching is not enabled.'
 tags: ['installation']
 draft: false
-unlisted: false
+unlisted: true
 ---
 
 ## Summary

--- a/docs/cwa/scripts/email-edf-machine-back-online-autofix.md
+++ b/docs/cwa/scripts/email-edf-machine-back-online-autofix.md
@@ -7,7 +7,7 @@ keywords: ['email', 'alert', 'monitor', 'notification', 'machine']
 description: 'This document outlines the functionality of a script designed to send email notifications when a monitored machine comes back online. It integrates with the CWM - Automate - Internal Monitor for effective monitoring and alerting.'
 tags: ['email']
 draft: false
-unlisted: false
+unlisted: true
 ---
 
 ## Summary

--- a/docs/cwa/scripts/fast-boot-disable.md
+++ b/docs/cwa/scripts/fast-boot-disable.md
@@ -7,7 +7,7 @@ keywords: ['windows', 'registry', 'fast', 'boot', 'shutdown']
 description: 'This document details a script designed to disable the Windows Fast Boot feature by adjusting the local registry on the target device. Fast Boot can prevent a full kernel reboot during shutdown, potentially causing system issues and impacting patch installations. The script ensures proper functionality by requiring a device restart for changes to take effect.'
 tags: ['performance', 'reboot', 'registry', 'windows']
 draft: false
-unlisted: false
+unlisted: true
 ---
 
 ## Summary

--- a/docs/cwa/scripts/microsoft-onedrive-sync-status-dv.md
+++ b/docs/cwa/scripts/microsoft-onedrive-sync-status-dv.md
@@ -7,7 +7,7 @@ keywords: ['onedrive', 'sync', 'status', 'windows', 'script']
 description: 'This document details a script for collecting OneDrive sync status information from Windows machines, targeting Non-SharePoint Linked Sites. The script utilizes the Onedrive.dll module and requires an active user session to function correctly.'
 tags: ['performance', 'report', 'software', 'windows']
 draft: false
-unlisted: false
+unlisted: true
 ---
 
 ## Summary


### PR DESCRIPTION
Set the 'unlisted' flag to true for several ConnectWise Automate monitor and script documentation files. This change hides these docs from public listings, deprecating them.