### PR TITLE
Add PowerShell Disable-Defender docs

### DIFF
--- a/docs/powershell/disable-defender.md
+++ b/docs/powershell/disable-defender.md
@@ -1,0 +1,57 @@
+---
+id: 'ps-disable-defender'
+slug: /ps-disable-defender
+title: 'Disable Defender'
+title_meta: 'Disable Defender'
+keywords: ['Windows Defender', 'SentinelOne', 'antivirus', 'real-time protection']
+description: 'Disables Windows Defender real-time protection when a supported third-party antivirus service is detected.'
+tags: ['security']
+draft: false
+unlisted: false
+last_update:
+  date: 2025-06-04
+---
+
+## Description
+
+Disables Windows Defender real-time protection when a supported third-party antivirus service is detected. If Defender is already disabled, no action is taken.
+
+## Requirements
+
+- PowerShell 5+
+- Administrative privileges
+
+## Process
+
+1. Checks for the presence of a supported third-party antivirus service (currently SentinelOne).
+2. If no supported AV service is found, exits without changes.
+3. Queries Windows Defender real-time protection status.
+4. If Defender is already disabled, exits without changes.
+5. Disables Defender real-time protection.
+
+## Usage
+
+Checks for SentinelAgent service and disables Defender if it is enabled.
+
+```powershell
+.\Disable-Defender.ps1
+```
+
+## Supported Antivirus Products
+
+| Product      | Service Name   |
+|--------------|----------------|
+| SentinelOne  | SentinelAgent  |
+
+Additional products can be added to the `$supportedAVServices` array in the script.
+
+## Output
+
+    .\Disable-Defender-log.txt
+    .\Disable-Defender-error.txt
+
+## Changelog
+
+### 2025-06-04
+
+- Initial version of the document

--- a/docs/powershell/disable-defender.md
+++ b/docs/powershell/disable-defender.md
@@ -1,57 +1,84 @@
 ---
 id: '3e5e318a-85f8-408f-81fb-509c5afe18c9'
 slug: /3e5e318a-85f8-408f-81fb-509c5afe18c9
-title: 'Disable Defender'
-title_meta: 'Disable Defender'
+title: 'Disable-Defender'
+title_meta: 'Disable-Defender'
 keywords: ['Windows Defender', 'SentinelOne', 'antivirus', 'real-time protection']
 description: 'Disables Windows Defender real-time protection when a supported third-party antivirus service is detected.'
 tags: ['security']
 draft: false
 unlisted: false
 last_update:
-  date: 2025-06-04
+  date: 2026-06-10
 ---
 
 ## Description
 
-Disables Windows Defender real-time protection when a supported third-party antivirus service is detected. If Defender is already disabled, no action is taken.
+Disables Windows Defender real-time protection only when a supported third-party antivirus service is detected. If no supported service is found, or Defender real-time protection is already disabled, the script exits without making changes.
 
-## Requirements
+# Requirements
 
-- PowerShell 5+
-- Administrative privileges
+- PowerShell 5.0 or later
+- Run as Administrator
+- Access to PowerShell Gallery to install or update the `Strapper` module
+- Windows Defender cmdlets available (`Get-MpComputerStatus`, `Set-MpPreference`)
 
-## Process
+# Process
 
-1. Checks for the presence of a supported third-party antivirus service (currently SentinelOne).
-2. If no supported AV service is found, exits without changes.
-3. Queries Windows Defender real-time protection status.
-4. If Defender is already disabled, exits without changes.
-5. Disables Defender real-time protection.
+1. Sets TLS policy for secure module and web requests.
+2. Ensures the `Strapper` module is installed and up to date, then initializes the Strapper environment.
+3. Checks each value passed to `-SupportedAVServices` and looks for a matching Windows service.
+4. If no supported AV service is found, logs the result and exits.
+5. Reads current Defender real-time protection status.
+6. If Defender real-time protection is already disabled, logs the result and exits.
+7. Uses ShouldProcess support to safely apply Defender changes.
+8. Disables Defender real-time protection and logs success or error details.
 
-## Usage
+# Payload Usage
 
-Checks for SentinelAgent service and disables Defender if it is enabled.
+This script is executed directly and does not use a separate payload file. The `SupportedAVServices` parameter is required.
+
+Checks for `SentinelAgent` service and disables Defender if it is running and Defender is enabled.
 
 ```powershell
-.\Disable-Defender.ps1
+.\Disable-Defender.ps1 -SupportedAVServices 'SentinelAgent'
 ```
 
-## Supported Antivirus Products
+Checks for both `SentinelAgent` and `AnotherAVService` services and disables Defender if either is running and Defender is enabled.
 
-| Product      | Service Name   |
-|--------------|----------------|
-| SentinelOne  | SentinelAgent  |
+```powershell
+.\Disable-Defender.ps1 -SupportedAVServices 'SentinelAgent','AnotherAVService'
+```
 
-Additional products can be added to the `$supportedAVServices` array in the script.
+Checks for a non-existent AV service. Defender will not be disabled.
 
-## Output
+```powershell
+.\Disable-Defender.ps1 -SupportedAVServices 'NonExistentAV'
+```
+
+Simulates the process of checking for SentinelAgent and disabling Defender without making any changes.
+
+```powershell
+.\Disable-Defender.ps1 -SupportedAVServices 'SentinelAgent' -WhatIf
+```
+
+# Parameters
+
+| Parameter             | Alias | Required | Default | Type     | Description                                                              |
+| --------------------- | ----- | -------- | ------- | -------- | ------------------------------------------------------------------------ |
+| `SupportedAVServices` |       | True     |         | String[] | One or more antivirus service names to detect before disabling Defender. |
+| `WhatIf`              |       | False    | False   | Switch   | Simulates execution and shows what actions would be taken.               |
+
+# Output
+
+Location of output for log and error files.
 
     .\Disable-Defender-log.txt
     .\Disable-Defender-error.txt
 
+
 ## Changelog
 
-### 2025-06-04
+### 2026-06-10
 
 - Initial version of the document

--- a/docs/powershell/disable-defender.md
+++ b/docs/powershell/disable-defender.md
@@ -1,6 +1,6 @@
 ---
-id: 'ps-disable-defender'
-slug: /ps-disable-defender
+id: '3e5e318a-85f8-408f-81fb-509c5afe18c9'
+slug: /3e5e318a-85f8-408f-81fb-509c5afe18c9
 title: 'Disable Defender'
 title_meta: 'Disable Defender'
 keywords: ['Windows Defender', 'SentinelOne', 'antivirus', 'real-time protection']


### PR DESCRIPTION
Add a new docs page (docs/powershell/disable-defender.md) documenting a PowerShell script to disable Windows Defender real-time protection when a supported third-party AV (currently SentinelOne) is detected. Includes metadata, requirements, process steps, usage example, supported products table, expected output files, and an initial changelog entry.