### PR TITLE
Update manage-windowsinstallercache.md

### DIFF
--- a/docs/powershell/manage-windowsinstallercache.md
+++ b/docs/powershell/manage-windowsinstallercache.md
@@ -9,7 +9,7 @@ tags: ['windows', 'disk-cleanup', 'installation', 'security']
 draft: false
 unlisted: false
 last_update:
-  date: 2026-06-08
+  date: 2026-06-12
 ---
 
 ## Description
@@ -27,16 +27,16 @@ Identifies orphaned `.msi`, `.msp`, and `.mst` files in `C:\Windows\Installer` a
 Dry-run scan (default, no changes made):
 
 ```powershell
-.\Manage-WindowsInstallerCache.ps1 -Verbose
+.\Manage-WindowsInstallerCache.ps1
 ```
 
-Quarantine verified orphaned files:
+Quarantine verified orphaned files (UNVERIFIED files are logged but not moved):
 
 ```powershell
-.\Manage-WindowsInstallerCache.ps1 -Quarantine -Verbose
+.\Manage-WindowsInstallerCache.ps1 -Quarantine
 ```
 
-Quarantine orphaned and unverified files without prompting:
+Quarantine both orphaned and unverified files (all operations are non-interactive):
 
 ```powershell
 .\Manage-WindowsInstallerCache.ps1 -Quarantine -Force
@@ -62,23 +62,23 @@ Each file in the installer cache receives one of the following classifications:
 | --- | --- | --- |
 | `SAFE_ORPHAN` | No full-path or weak reference found; all validation sources enumerated cleanly. | Yes (default) |
 | `POSSIBLE_REFERENCE` | No full-path reference found, but filename-only evidence exists in one or more sources. | No |
-| `UNVERIFIED` | No reference found, but one or more validation layers failed to enumerate cleanly. | Only with `-Force` or operator confirmation |
+| `UNVERIFIED` | No reference found, but one or more validation layers failed to enumerate cleanly. | Only with `-Force` |
 | `ACTIVE_REFERENCE` | File found in one or more full-path validation sources. | No |
 
 ## Parameters
 
-| Parameter | Required | Default | Type | Description |
-| --- | --- | --- | --- | --- |
-| `ScanOnly` | No | Active when no mode switch is supplied | Switch | Performs discovery and classification only. |
-| `Quarantine` | No | `False` | Switch | Moves `SAFE_ORPHAN` files to the quarantine folder (`C:\Windows\Installer\_Quarantine` by default). |
-| `Delete` | No | `False` | Switch | Permanently deletes previously quarantined files referenced by a manifest. |
-| `Restore` | No | `False` | Switch | Restores previously quarantined files from a manifest back to their original location. |
-| `RestoreFromManifest` | No | Newest manifest in log path | String | Path to the manifest used for restore. |
-| `ManifestPath` | No | Newest manifest in log path | String | Path to the manifest produced by a `-Quarantine` run. Created automatically when at least one file is quarantined — records each file's original path, quarantine destination, hash, size, classification, and timestamp. Supply this path to `-Delete` or `-Restore`. |
-| `InstallerPath` | No | `C:\Windows\Installer` | String | Root installer cache path to inspect. |
-| `QuarantinePath` | No | `C:\Windows\Installer\_Quarantine` | String | Quarantine destination folder. |
-| `LogPath` | No | `C:\ProgramData\_Automation\Script\Manage-WindowsInstallerCache` | String | Folder for JSON, CSV, and manifest output. |
-| `Force` | No | `False` | Switch | Suppresses confirmation prompts for `UNVERIFIED` files during quarantine, quarantining them automatically. |
+| Parameter | Required | Default | ParameterSet | Type | Description |
+| --- | --- | --- | --- | --- | --- |
+| `ScanOnly` | No | Active when no mode switch is supplied | Scan | Switch | Performs discovery and classification only. |
+| `Quarantine` | No | `False` | Quarantine | Switch | Moves `SAFE_ORPHAN` files to the quarantine folder (`C:\Windows\Installer\_Quarantine` by default). |
+| `Delete` | No | `False` | Delete | Switch | Permanently deletes previously quarantined files referenced by a manifest. |
+| `Restore` | No | `False` | Restore | Switch | Restores previously quarantined files from a manifest back to their original location. |
+| `RestoreFromManifest` | No | Newest manifest in log path | Restore | String | Path to the manifest used for restore. |
+| `ManifestPath` | No | Newest manifest in log path | Delete | String | Path to the manifest produced by a `-Quarantine` run. Created automatically when at least one file is quarantined — records each file's original path, quarantine destination, hash, size, classification, and timestamp. Supply this path to `-Delete` or `-Restore`. |
+| `InstallerPath` | No | `C:\Windows\Installer` | Scan, Quarantine | String | Root installer cache path to inspect. |
+| `QuarantinePath` | No | `C:\Windows\Installer\_Quarantine` | Quarantine | String | Quarantine destination folder. |
+| `LogPath` | No | `C:\ProgramData\_Automation\Script\Manage-WindowsInstallerCache` | All | String | Folder for JSON, CSV, and manifest output. |
+| `Force` | No | `False` | Quarantine | Switch | Includes `UNVERIFIED` files in quarantine operations. Without this switch, `UNVERIFIED` files are only logged in the CSV/JSON output and never quarantined. |
 
 ## Output
 
@@ -116,6 +116,12 @@ CsvLogPath           : C:\ProgramData\_Automation\Script\Manage-WindowsInstaller
 ```
 
 ## Changelog
+
+### 2026-06-12
+
+- Script is now fully non-interactive; no confirmation prompts under any parameter combination
+- `-Force` controls whether `UNVERIFIED` files are quarantined (without it they are only logged)
+- Parameters restricted to their relevant parameter sets (`-Force`, `-QuarantinePath` only available with `-Quarantine`; `-InstallerPath` with Scan/Quarantine)
 
 ### 2026-06-09
 


### PR DESCRIPTION
- Script is now fully non-interactive; no confirmation prompts under any parameter combination
- `-Force` controls whether `UNVERIFIED` files are quarantined (without it they are only logged)
- Parameters restricted to their relevant parameter sets (`-Force`, `-QuarantinePath` only available with `-Quarantine`; `-InstallerPath` with Scan/Quarantine)