### PR TITLE
Add Get-LastServerReboot docs

### DIFF
--- a/docs/powershell/get-lastreboottime.md
+++ b/docs/powershell/get-lastreboottime.md
@@ -1,15 +1,15 @@
 ---
 id: 'ab26f055-f420-4e35-8241-8f868c940b6d'
 slug: /ab26f055-f420-4e35-8241-8f868c940b6d
-title: 'Get-LastServerReboot'
-title_meta: 'Get-LastServerReboot'
+title: 'Get-LastRebootTime'
+title_meta: 'Get-LastRebootTime'
 keywords: ['reboot', 'server', 'workstation', 'uptime', 'monitoring', 'threshold', 'alerting']
 description: 'Alerts if a device has not been rebooted within a configurable number of days.'
 tags: ['monitoring', 'reboot', 'alerting', 'windows']
 draft: false
 unlisted: false
 last_update:
-  date: 2026-06-26
+  date: 2026-06-29
 ---
 
 ## Description
@@ -28,25 +28,25 @@ If no parameters are provided, the script uses a default threshold of **8 days**
 ### Use default 8-day threshold
 
 ```powershell
-.\Get-LastServerReboot.ps1
+.\Get-LastRebootTime.ps1
 ```
 
 ### Set a custom day threshold
 
 ```powershell
-.\Get-LastServerReboot.ps1 -ThresholdDays 14
+.\Get-LastRebootTime.ps1 -ThresholdDays 14
 ```
 
 ### Test with a short minute-based threshold
 
 ```powershell
-.\Get-LastServerReboot.ps1 -ThresholdMinutes 30
+.\Get-LastRebootTime.ps1 -ThresholdMinutes 30
 ```
 
 ### Combine days and minutes
 
 ```powershell
-.\Get-LastServerReboot.ps1 -ThresholdDays 7 -ThresholdMinutes 720
+.\Get-LastRebootTime.ps1 -ThresholdDays 7 -ThresholdMinutes 720
 ```
 
 ## Parameters
@@ -73,8 +73,8 @@ If no parameters are provided, the script uses a default threshold of **8 days**
 Log files are written to the script directory and are **overwritten on each run** so only the most recent execution is stored:
 
 ```plaintext
-Get-LastServerReboot-log.txt
-Get-LastServerReboot-error.txt
+Get-LastRebootTime-log.txt
+Get-LastRebootTime-error.txt
 ```
 
 Each run logs:
@@ -89,6 +89,6 @@ If the last boot time cannot be retrieved, the script logs an error and exits wi
 
 ## Changelog
 
-### 2026-06-26
+### 2026-06-29
 
 - Initial version of the document

--- a/docs/powershell/get-lastserverreboot.md
+++ b/docs/powershell/get-lastserverreboot.md
@@ -9,7 +9,7 @@ tags: ['monitoring', 'reboot', 'alerting', 'windows']
 draft: false
 unlisted: false
 last_update:
-  date: 2026-06-25
+  date: 2026-06-26
 ---
 
 ## Description
@@ -23,18 +23,25 @@ Alerts if a server hasn't been rebooted within a configurable number of days (an
 
 ## Usage
 
+**Daily monitoring automation (alert if no reboot in 8 days):**
+
 ```powershell
 .\Get-LastServerReboot.ps1
 ```
+
+**Servers with a longer maintenance window (14 days):**
 
 ```powershell
 .\Get-LastServerReboot.ps1 -ThresholdDays 14
 ```
 
+**Quick testing with a 30-minute threshold:**
+
 ```powershell
 .\Get-LastServerReboot.ps1 -ThresholdDays 0 -ThresholdMinutes 30
 ```
 
+**Check reboot time withing 7 days and 720 minutes**
 ```powershell
 .\Get-LastServerReboot.ps1 -ThresholdDays 7 -ThresholdMinutes 720
 ```
@@ -69,3 +76,7 @@ Each run logs:
 - Result (OK with time remaining, or ALERT with uptime details)
 
 ## Changelog
+
+### 2026-06-26
+
+- Initial version of the document

--- a/docs/powershell/get-lastserverreboot.md
+++ b/docs/powershell/get-lastserverreboot.md
@@ -3,8 +3,8 @@ id: 'ab26f055-f420-4e35-8241-8f868c940b6d'
 slug: /ab26f055-f420-4e35-8241-8f868c940b6d
 title: 'Get-LastServerReboot'
 title_meta: 'Get-LastServerReboot'
-keywords: ['reboot', 'server', 'uptime', 'monitoring', 'threshold', 'alerting']
-description: 'Alerts if a server has not been rebooted within a configurable number of days.'
+keywords: ['reboot', 'server', 'workstation', 'uptime', 'monitoring', 'threshold', 'alerting']
+description: 'Alerts if a device has not been rebooted within a configurable number of days.'
 tags: ['monitoring', 'reboot', 'alerting', 'windows']
 draft: false
 unlisted: false
@@ -14,7 +14,7 @@ last_update:
 
 ## Description
 
-Alerts if a server hasn't been rebooted within a configurable number of days (and optionally minutes). Designed for RMM automation to proactively flag servers that have exceeded their expected reboot cycle.
+Alerts if a device (workstation or server) hasn't been rebooted within a configurable number of days (and optionally minutes). Designed for RMM automation to proactively flag devices that have exceeded their expected reboot cycle.
 
 ## Requirements
 
@@ -23,44 +23,54 @@ Alerts if a server hasn't been rebooted within a configurable number of days (an
 
 ## Usage
 
-**Daily monitoring automation (alert if no reboot in 8 days):**
+If no parameters are provided, the script uses a default threshold of **8 days** and alerts (exit code 1) if the device has not rebooted within that window.
+
+### Use default 8-day threshold
 
 ```powershell
 .\Get-LastServerReboot.ps1
 ```
 
-**Servers with a longer maintenance window (14 days):**
+### Set a custom day threshold
 
 ```powershell
 .\Get-LastServerReboot.ps1 -ThresholdDays 14
 ```
 
-**Quick testing with a 30-minute threshold:**
+### Test with a short minute-based threshold
 
 ```powershell
-.\Get-LastServerReboot.ps1 -ThresholdDays 0 -ThresholdMinutes 30
+.\Get-LastServerReboot.ps1 -ThresholdMinutes 30
 ```
 
-**Check reboot time withing 7 days and 720 minutes**
+### Combine days and minutes
+
 ```powershell
 .\Get-LastServerReboot.ps1 -ThresholdDays 7 -ThresholdMinutes 720
 ```
 
 ## Parameters
 
-| Parameter          | Alias | Required | Default | Type | Description                                                  |
-| ------------------ | ----- | -------- | ------- | ---- | ------------------------------------------------------------ |
-| `ThresholdDays`    |       | False    | `8`     | Int  | Number of days since last reboot before alerting             |
-| `ThresholdMinutes` |       | False    | `0`     | Int  | Additional minutes to add to the threshold (useful for testing) |
+| Parameter          | Alias | Required | Default | Type  | Description                                                                                                      |
+| ------------------ | ----- | -------- | ------- | ----- | ---------------------------------------------------------------------------------------------------------------- |
+| `ThresholdDays`    |       | False    | `8`     | Int   | Number of days since last reboot before alerting. Defaults to `0` when only `-ThresholdMinutes` is specified.     |
+| `ThresholdMinutes` |       | False    | `0`     | Int   | Number of minutes to use as the threshold (or to add to `-ThresholdDays` when both are specified).                |
+
+`-ThresholdDays` and `-ThresholdMinutes` can be used independently or together:
+
+- If **neither** is specified, the default threshold is **8 days**.
+- If only `-ThresholdDays` is specified, that value is the threshold.
+- If only `-ThresholdMinutes` is specified, `-ThresholdDays` is automatically set to `0` so the threshold is based solely on minutes.
+- If **both** are specified, their values are combined into a single threshold.
 
 ## Output
 
-| Exit Code | Meaning                                                |
-| --------- | ------------------------------------------------------ |
-| `0`       | Server is within the reboot threshold                  |
-| `1`       | Server has exceeded the reboot threshold (alert condition) |
+| Exit Code | Meaning                                                    |
+| --------- | ---------------------------------------------------------- |
+| `0`       | Device is within the reboot threshold                      |
+| `1`       | Device has exceeded the reboot threshold (alert condition)  |
 
-Log files are written to the script directory and overwritten on each run:
+Log files are written to the script directory and are **overwritten on each run** so only the most recent execution is stored:
 
 ```plaintext
 Get-LastServerReboot-log.txt
@@ -69,11 +79,13 @@ Get-LastServerReboot-error.txt
 
 Each run logs:
 
-- Server name
+- Device name
 - Last reboot timestamp
 - Current uptime (days, hours, minutes)
 - Configured threshold
 - Result (OK with time remaining, or ALERT with uptime details)
+
+If the last boot time cannot be retrieved, the script logs an error and exits with code 1.
 
 ## Changelog
 

--- a/docs/powershell/get-lastserverreboot.md
+++ b/docs/powershell/get-lastserverreboot.md
@@ -1,0 +1,71 @@
+---
+id: 'ab26f055-f420-4e35-8241-8f868c940b6d'
+slug: /ab26f055-f420-4e35-8241-8f868c940b6d
+title: 'Get-LastServerReboot'
+title_meta: 'Get-LastServerReboot'
+keywords: ['reboot', 'server', 'uptime', 'monitoring', 'threshold', 'alerting']
+description: 'Alerts if a server has not been rebooted within a configurable number of days.'
+tags: ['monitoring', 'reboot', 'alerting', 'windows']
+draft: false
+unlisted: false
+last_update:
+  date: 2026-06-25
+---
+
+## Description
+
+Alerts if a server hasn't been rebooted within a configurable number of days (and optionally minutes). Designed for RMM automation to proactively flag servers that have exceeded their expected reboot cycle.
+
+## Requirements
+
+- Windows with PowerShell 5.1 or later
+- Internet access on first run (to install or update the `Strapper` module from PSGallery)
+
+## Usage
+
+```powershell
+.\Get-LastServerReboot.ps1
+```
+
+```powershell
+.\Get-LastServerReboot.ps1 -ThresholdDays 14
+```
+
+```powershell
+.\Get-LastServerReboot.ps1 -ThresholdDays 0 -ThresholdMinutes 30
+```
+
+```powershell
+.\Get-LastServerReboot.ps1 -ThresholdDays 7 -ThresholdMinutes 720
+```
+
+## Parameters
+
+| Parameter          | Alias | Required | Default | Type | Description                                                  |
+| ------------------ | ----- | -------- | ------- | ---- | ------------------------------------------------------------ |
+| `ThresholdDays`    |       | False    | `8`     | Int  | Number of days since last reboot before alerting             |
+| `ThresholdMinutes` |       | False    | `0`     | Int  | Additional minutes to add to the threshold (useful for testing) |
+
+## Output
+
+| Exit Code | Meaning                                                |
+| --------- | ------------------------------------------------------ |
+| `0`       | Server is within the reboot threshold                  |
+| `1`       | Server has exceeded the reboot threshold (alert condition) |
+
+Log files are written to the script directory and overwritten on each run:
+
+```plaintext
+Get-LastServerReboot-log.txt
+Get-LastServerReboot-error.txt
+```
+
+Each run logs:
+
+- Server name
+- Last reboot timestamp
+- Current uptime (days, hours, minutes)
+- Configured threshold
+- Result (OK with time remaining, or ALERT with uptime details)
+
+## Changelog


### PR DESCRIPTION
Add a new documentation page for the Get-LastServerReboot PowerShell script at docs/powershell/get-lastserverreboot.md. The file includes frontmatter metadata, a description, requirements, usage examples, parameter table (ThresholdDays/ThresholdMinutes and defaults), output/exit-code semantics, logging details, and a changelog placeholder.