### PR TITLE
Update oem-update-with-prompt.md

### DIFF
--- a/docs/ninjaone/automations/oem-update-with-prompt.md
+++ b/docs/ninjaone/automations/oem-update-with-prompt.md
@@ -9,7 +9,7 @@ tags: ['windows', 'dell', 'lenovo', 'hp', 'notifications', 'drivers', 'bios', 'f
 draft: false
 unlisted: false
 last_update:
-  date: 2026-06-19
+  date: 2026-07-14
 ---
 
 ## Overview
@@ -82,7 +82,7 @@ Run with user parameter `SkipWeekends = True`. Please ensure that the correspond
 Expected output:
 
 - There will be no popup get generated on the users machine during weekend.
-- Will is usefull as user will not miss any popup during weekends.
+- Will is useful as user will not miss any popup during weekends.
 
 
 ## Sample Prompts
@@ -95,7 +95,7 @@ This prompt is shown while the update needs to be schedule on particular time.
 ![Image 2](../../../static/img/docs/6c133406-ba21-476d-baab-32acb772acaa/schedule-option.webp)
 
 
-The prompt shows the confirmation that update is scheduled and will start on the particular time and need aknowledgement.  
+The prompt shows the confirmation that update is scheduled and will start on the particular time and need acknowledgement.  
 ![Image 3](../../../static/img/docs/6c133406-ba21-476d-baab-32acb772acaa/schedule-firmware.webp)
 
 
@@ -133,7 +133,7 @@ The prompt shows the confirmation that update has been completed and reboot is r
 
 ### 2026-07-14
 
-Bug Fix: Added missing `iconLocalPath` and `headerImageLocalPath` variable definitions required for loading prompt images correctly.
+- **Bug Fix:** Added missing `iconLocalPath` and `headerImageLocalPath` variable definitions required for loading prompt images correctly.
 
 
 ### 2026-06-19

--- a/docs/ninjaone/automations/oem-update-with-prompt.md
+++ b/docs/ninjaone/automations/oem-update-with-prompt.md
@@ -131,6 +131,11 @@ The prompt shows the confirmation that update has been completed and reboot is r
 
 ## Changelog
 
+### 2026-07-14
+
+Bug Fix: Added missing `iconLocalPath` and `headerImageLocalPath` variable definitions required for loading prompt images correctly.
+
+
 ### 2026-06-19
 
 - Initial version of the document.


### PR DESCRIPTION


Bug Reported
The prompt was not displaying the icon and header image due to missing variable definitions in the script.

Resolution:
Added the missing variables for icon and header image local paths to ensure the images are correctly loaded and displayed in the prompt.

What steps were changed in the content:
- Added the missing variable definitions:
  - $iconLocalPath = '{0}\icon.png' -f $workingDirectory
  - $headerImageLocalPath = '{0}\header.png' -f $workingDirectory
- Updated the script logic to correctly reference the local paths for the icon and header image.
- Verified that both images are displayed correctly in the prompt after the changes.