### PR TITLE
Updated Installed Remote Tools Solution

### DIFF
--- a/docs/ninjaone/compound-conditions/audit-installed-remote-tools-servers-ticketing.md
+++ b/docs/ninjaone/compound-conditions/audit-installed-remote-tools-servers-ticketing.md
@@ -9,11 +9,11 @@ tags: ['windows', 'auditing', 'security']
 draft: false
 unlisted: false
 last_update:
-  date: 2026-06-24
+  date: 2026-07-31
 ---
 
 ## Summary
-Triggers the [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b719351b7a1e) automation on Windows servers where deployment is enabled and creates tickets if `Windows (with Ticketing)`, `Windows Servers (with Ticketing)` is selected at [cPVAL Enable Remote Tools Detection](/docs/175e9426-65df-4a50-a0d6-e134fa9d9651) custom Field.
+Triggers the [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b719351b7a1e) automation on Windows servers. Generate tickets if `Windows (with Ticketing)`, `Windows Servers (with Ticketing)` is selected at [cPVAL Enable Remote Tools Detection](/docs/175e9426-65df-4a50-a0d6-e134fa9d9651) custom Field.
 
 ## Details
 

--- a/docs/ninjaone/compound-conditions/audit-installed-remote-tools-servers.md
+++ b/docs/ninjaone/compound-conditions/audit-installed-remote-tools-servers.md
@@ -9,7 +9,7 @@ tags: ['windows', 'auditing', 'security']
 draft: false
 unlisted: true
 last_update:
-  date: 2026-07-31
+  date: 2026-08-04
 ---
 
 ## Summary
@@ -31,7 +31,7 @@ Triggers the [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b71935
 
 ## Changelog
 
-### 2026-07-31
+### 2026-08-04
 
 - Removed the compound conditions as the ticketing compound conditions execute the script regardless of whether the custom fields are selected. If ticketing conditions are imported into the environment, the audit will run automatically, and tickets will only be generated when the ticketing options are enabled in the cPVAL Enable Remote Tools Detection custom field.
 

--- a/docs/ninjaone/compound-conditions/audit-installed-remote-tools-servers.md
+++ b/docs/ninjaone/compound-conditions/audit-installed-remote-tools-servers.md
@@ -7,9 +7,9 @@ keywords: ['installed-tools', 'remote-access', 'remote-access-tools-auditing']
 description: 'Triggers the `Installed Remote Tools Audit` automation on Windows servers where deployment is enabled.'
 tags: ['windows', 'auditing', 'security']
 draft: false
-unlisted: false
+unlisted: true
 last_update:
-  date: 2026-06-24
+  date: 2026-07-31
 ---
 
 ## Summary
@@ -30,6 +30,10 @@ Triggers the [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b71935
 - [Compound Condition Configuration](https://github.com/ProVal-Tech/ninjarmm/blob/main/compound-conditions/audit-installed-remote-tools-servers.toml)
 
 ## Changelog
+
+### 2026-07-31
+
+- Removed the compound conditions as the ticketing compound conditions execute the script regardless of whether the custom fields are selected. If ticketing conditions are imported into the environment, the audit will run automatically, and tickets will only be generated when the ticketing options are enabled in the cPVAL Enable Remote Tools Detection custom field.
 
 ### 2026-06-24
 

--- a/docs/ninjaone/compound-conditions/audit-installed-remote-tools-workstations-ticketing.md
+++ b/docs/ninjaone/compound-conditions/audit-installed-remote-tools-workstations-ticketing.md
@@ -9,11 +9,11 @@ tags: ['windows', 'auditing', 'security']
 draft: false
 unlisted: false
 last_update:
-  date: 2026-06-24
+  date: 2026-07-31
 ---
 
 ## Summary
-Triggers the [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b719351b7a1e) automation on Windows workstations where deployment is enabled and creates tickets if `Windows (with Ticketing)`, `Windows Workstations (with Ticketing)` is selected at [cPVAL Enable Remote Tools Detection](/docs/175e9426-65df-4a50-a0d6-e134fa9d9651) custom Field.
+Triggers the [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b719351b7a1e) automation on Windows workstations. Generate tickets if `Windows (with Ticketing)`, `Windows Workstations (with Ticketing)` is selected at [cPVAL Enable Remote Tools Detection](/docs/175e9426-65df-4a50-a0d6-e134fa9d9651) custom Field.
 
 ## Details
 

--- a/docs/ninjaone/compound-conditions/audit-installed-remote-tools-workstations.md
+++ b/docs/ninjaone/compound-conditions/audit-installed-remote-tools-workstations.md
@@ -9,7 +9,7 @@ tags: ['windows', 'auditing', 'security']
 draft: false
 unlisted: true
 last_update:
-  date: 2026-07-31
+  date: 2026-08-04
 ---
 
 ## Summary
@@ -31,7 +31,7 @@ Triggers the [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b71935
 
 ## Changelog
 
-### 2026-07-31
+### 2026-08-04
 
 - Removed the compound conditions as the ticketing compound conditions execute the script regardless of whether the custom fields are selected. If ticketing conditions are imported into the environment, the audit will run automatically, and tickets will only be generated when the ticketing options are enabled in the cPVAL Enable Remote Tools Detection custom field.
 

--- a/docs/ninjaone/compound-conditions/audit-installed-remote-tools-workstations.md
+++ b/docs/ninjaone/compound-conditions/audit-installed-remote-tools-workstations.md
@@ -7,9 +7,9 @@ keywords: ['installed-tools', 'remote-access', 'remote-access-tools-auditing']
 description: 'Triggers the `Installed Remote Tools Audit` automation on Windows workstations where deployment is enabled.'
 tags: ['windows', 'auditing', 'security']
 draft: false
-unlisted: false
+unlisted: true
 last_update:
-  date: 2026-06-24
+  date: 2026-07-31
 ---
 
 ## Summary
@@ -30,6 +30,10 @@ Triggers the [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b71935
 - [Compound Condition Configuration](https://github.com/ProVal-Tech/ninjarmm/blob/main/compound-conditions/audit-installed-remote-tools-workstations.toml)
 
 ## Changelog
+
+### 2026-07-31
+
+- Removed the compound conditions as the ticketing compound conditions execute the script regardless of whether the custom fields are selected. If ticketing conditions are imported into the environment, the audit will run automatically, and tickets will only be generated when the ticketing options are enabled in the cPVAL Enable Remote Tools Detection custom field.
 
 ### 2026-06-24
 

--- a/docs/ninjaone/custom-fields/cpval-enable-remote-tools-detection.md
+++ b/docs/ninjaone/custom-fields/cpval-enable-remote-tools-detection.md
@@ -9,7 +9,7 @@ tags: ['windows', 'auditing', 'security']
 draft: false
 unlisted: false
 last_update:
-  date: 2026-06-24
+  date: 2026-07-31
 ---
 
 ## Summary
@@ -20,7 +20,7 @@ Select the required OS to start detecting Unauthorized remote tools. `With Ticke
 
 | Label | Field Name | Definition Scope | Type | Available Options | Default Value | Required  | Technician Permission | Automation Permission | API Permission | Custom Field Tab Name |
 | ----- | ---------- | ---------------- | ---- | ------------ | ------------- | --------- | --------------------- | --------------------- | -------------- | ----------- |
-|cPVAL Enable Remote Tools Detection|cpvalEnableRemoteToolsDetection|`Organization`, `Location`, `Device` | Drop-down | `Disable`, `Windows`, `Windows Workstations`, `Windows Servers`, `Windows (with Ticketing)`, `Windows Workstations (with Ticketing)`,`Windows Servers (with Ticketing)`| - | False | Editable | Read/Write | Read/Write |  Remote Access Tools |
+|cPVAL Enable Remote Tools Detection|cpvalEnableRemoteToolsDetection|`Organization`, `Location`, `Device` | Drop-down | `Disable`,`Windows (with Ticketing)`, `Windows Workstations (with Ticketing)`,`Windows Servers (with Ticketing)`| - | False | Editable | Read/Write | Read/Write |  Remote Access Tools |
 
 ## Dependencies
 
@@ -35,6 +35,10 @@ Select the required OS to start detecting Unauthorized remote tools. `With Ticke
 ![Image1](../../../static/img/docs/175e9426-65df-4a50-a0d6-e134fa9d9651/image1.webp)
 
 ## Changelog
+
+### 2026-07-31
+
+- Removed the `Windows`, `Windows Workstations` and `Windows Servers` options, as the audit is not dependent on these selections. The audit will run regardless of whether these options are selected.
 
 ### 2026-06-24
 

--- a/docs/ninjaone/custom-fields/cpval-enable-remote-tools-detection.md
+++ b/docs/ninjaone/custom-fields/cpval-enable-remote-tools-detection.md
@@ -9,7 +9,7 @@ tags: ['windows', 'auditing', 'security']
 draft: false
 unlisted: false
 last_update:
-  date: 2026-07-31
+  date: 2026-08-04
 ---
 
 ## Summary
@@ -36,7 +36,7 @@ Select the required OS to start detecting Unauthorized remote tools. `With Ticke
 
 ## Changelog
 
-### 2026-07-31
+### 2026-08-04
 
 - Removed the `Windows`, `Windows Workstations` and `Windows Servers` options, as the audit is not dependent on these selections. The audit will run regardless of whether these options are selected.
 

--- a/docs/solutions/installed-remote-tools-audit-ninja.md
+++ b/docs/solutions/installed-remote-tools-audit-ninja.md
@@ -9,7 +9,7 @@ tags: ['windows', 'auditing', 'security']
 draft: false
 unlisted: false
 last_update:
-  date: 2026-07-31
+  date: 2026-08-04
 ---
 
 ## Purpose
@@ -88,10 +88,10 @@ Tool display names supported by this script:
 
 ## Changelog
 
-### 2026-07-31
+### 2026-08-04
 
 - Updated the `cPVAL Enable Remote Tools Detection` custom field to include only ticketing options, as the audit is automatically performed by the ticketing compound conditions.
-- Removed the audit compound conditions `Audit Installed Remote Tools - Workstations` and `Audit Installed Remote Tools - Server`, as the ticketing compound conditions execute the script regardless of whether the custom fields are selected. If ticketing conditions are imported into the environment, the audit will run automatically, and tickets will only be generated when the ticketing options are enabled in the cPVAL Enable Remote Tools Detection custom field.
+- Removed the audit compound conditions `Audit Installed Remote Tools - Workstations` and `Audit Installed Remote Tools - Server`, as the ticketing compound conditions execute the script regardless of whether the custom fields are selected. If ticketing conditions are imported into the environment, the audit will run automatically, and tickets will only be generated when the ticketing options are enabled in the `cPVAL Enable Remote Tools Detection` custom field.
 
 ### 2026-07-27
 

--- a/docs/solutions/installed-remote-tools-audit-ninja.md
+++ b/docs/solutions/installed-remote-tools-audit-ninja.md
@@ -9,7 +9,7 @@ tags: ['windows', 'auditing', 'security']
 draft: false
 unlisted: false
 last_update:
-  date: 2026-06-24
+  date: 2026-07-31
 ---
 
 ## Purpose
@@ -66,9 +66,7 @@ Tool display names supported by this script:
 | [Custom field - cPVAL Detected Remote Tool Names](/docs/6238b6b2-1e19-4840-8f54-0d952a694c8a)  | Custom Field | Custom field stores the remote management applications list names gathered by the script [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b719351b7a1e). |
 | [Installed Remote Tool Audits](/docs/8111fecc-61de-4c72-933c-b719351b7a1e)  | Automation | Script to audit Windows endpoint for known remote access tools using multiple detection methods. |
 | [Unauthorized Remote Tools](/docs/d733a553-e69b-4c4e-b209-f05102bae6e5)  | Ticket Template | This ticket template configures how a ConnectWise Manage ticket will be generated in response to the [Audit Installed Remote Tools - Workstation](/docs/05f4af3f-1f26-4080-aec5-fc9bbc0df5fc) and [Audit Installed Remote Tools - Server](/docs/3ed66f5a-e52f-4f79-a8c0-783597a4d439) compound conditions. |
-| [Audit Installed Remote Tools - Workstation](/docs/05f4af3f-1f26-4080-aec5-fc9bbc0df5fc)  | Compound Condition | Triggers the [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b719351b7a1e) automation on Windows workstations where deployment is enabled. |
 | [Audit Installed Remote Tools (with Ticketing) - Workstation](/docs/fcff5bd0-198e-4b40-a877-61efa4bec69e)  | Compound Condition | Triggers the [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b719351b7a1e) automation on Windows workstations where deployment is enabled and creates tickets if `Windows (with Ticketing)`, `Windows Workstations (with Ticketing)` is selected at [cPVAL Enable Remote Tools Detection](/docs/175e9426-65df-4a50-a0d6-e134fa9d9651) custom Field. |
-| [Audit Installed Remote Tools - Server](/docs/3ed66f5a-e52f-4f79-a8c0-783597a4d439)  | Compound Condition | Triggers the [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b719351b7a1e) automation on Windows Servers where deployment is enabled. |
 | [Audit Installed Remote Tools (with Ticketing) - Servers](/docs/d19f2a89-9667-41df-93ce-797295aa542a)  | Compound Condition | Triggers the [Installed Remote Tools Audit](/docs/8111fecc-61de-4c72-933c-b719351b7a1e) automation on Windows servers where deployment is enabled and creates tickets if `Windows (with Ticketing)`, `Windows Servers (with Ticketing)` is selected at [cPVAL Enable Remote Tools Detection](/docs/175e9426-65df-4a50-a0d6-e134fa9d9651) custom Field. |
 
 
@@ -82,18 +80,18 @@ Tool display names supported by this script:
 2. Create the [Automation - Installed Remote Tool Audits](/docs/8111fecc-61de-4c72-933c-b719351b7a1e) 
 3. Create the Ticket template: [Unauthorized Remote Tools](/docs/d733a553-e69b-4c4e-b209-f05102bae6e5)
 4. Create the below Compound Conditions using the implementation instruction provided in the documents.
-    - [Audit Installed Remote Tools - Workstation](/docs/05f4af3f-1f26-4080-aec5-fc9bbc0df5fc) 
-    - [Audit Installed Remote Tools - Server](/docs/3ed66f5a-e52f-4f79-a8c0-783597a4d439)
     - [Audit Installed Remote Tools (with Ticketing) - Servers](/docs/d19f2a89-9667-41df-93ce-797295aa542a)
     - [Audit Installed Remote Tools (with Ticketing) - Workstation](/docs/fcff5bd0-198e-4b40-a877-61efa4bec69e)
-5. Select `Windows`, `Windows Workstations`, or `Windows Servers` from the custom field [cPVAL Enable Remote Tools Detection](/docs/175e9426-65df-4a50-a0d6-e134fa9d9651)  to enable just auditing for remote tools. These options will enable the below compound conditions:
-    - [Audit Installed Remote Tools - Workstation](/docs/05f4af3f-1f26-4080-aec5-fc9bbc0df5fc) 
-    - [Audit Installed Remote Tools - Server](/docs/3ed66f5a-e52f-4f79-a8c0-783597a4d439)
-6. Select `Windows (with Ticketing)`, `Windows Workstations (with Ticketing)`, or `Windows Servers (with Ticketing)` from the custom field [cPVAL Enable Remote Tools Detection](/docs/175e9426-65df-4a50-a0d6-e134fa9d9651) to enable the below compound conditions which will create a ticket if any unauthorized remote tool is detected:
+5. Importing the below compound conditions will automatically enable audit Remote Access tools audit in the environment. Select `Windows (with Ticketing)`, `Windows Workstations (with Ticketing)`, or `Windows Servers (with Ticketing)` from the custom field [cPVAL Enable Remote Tools Detection](/docs/175e9426-65df-4a50-a0d6-e134fa9d9651) to enable the below compound conditions to create tickets if any unauthorized remote tool is detected:
     - [Audit Installed Remote Tools (with Ticketing) - Servers](/docs/d19f2a89-9667-41df-93ce-797295aa542a)
     - [Audit Installed Remote Tools (with Ticketing) - Workstation](/docs/fcff5bd0-198e-4b40-a877-61efa4bec69e)
 
 ## Changelog
+
+### 2026-07-31
+
+- Updated the `cPVAL Enable Remote Tools Detection` custom field to include only ticketing options, as the audit is automatically performed by the ticketing compound conditions.
+- Removed the audit compound conditions `Audit Installed Remote Tools - Workstations` and `Audit Installed Remote Tools - Server`, as the ticketing compound conditions execute the script regardless of whether the custom fields are selected. If ticketing conditions are imported into the environment, the audit will run automatically, and tickets will only be generated when the ticketing options are enabled in the cPVAL Enable Remote Tools Detection custom field.
 
 ### 2026-07-27
 


### PR DESCRIPTION
- Updated the `cPVAL Enable Remote Tools Detection` custom field to include only ticketing options, as the audit is automatically performed by the ticketing compound conditions.
- Removed the audit compound conditions `Audit Installed Remote Tools - Workstations` and `Audit Installed Remote Tools - Server`, as the ticketing compound conditions execute the script regardless of whether the custom fields are selected. If ticketing conditions are imported into the environment, the audit will run automatically, and tickets will only be generated when the ticketing options are enabled in the cPVAL Enable Remote Tools Detection custom field.